### PR TITLE
Fix for the profile menu being transparent

### DIFF
--- a/darker-medium.user.css
+++ b/darker-medium.user.css
@@ -186,7 +186,7 @@ body .u-tintSpectrum .u-accentColor--buttonNormal.button--withChrome.is-active:n
 }
 
 div.popover {
-	background: #1D1D1D !important;
+	background: #1d1d1d !important;
 }
 
 .readNextPromo,

--- a/darker-medium.user.css
+++ b/darker-medium.user.css
@@ -185,7 +185,10 @@ body .u-tintSpectrum .u-accentColor--buttonNormal.button--withChrome.is-active:n
 	background-color: transparent !important;
 }
 
-div.popover,
+div.popover {
+	background: #1D1D1D !important;
+}
+
 .readNextPromo,
 footer .container > div {
 	background: transparent none !important;

--- a/style.css
+++ b/style.css
@@ -153,7 +153,10 @@ body .u-tintSpectrum .u-accentColor--buttonNormal.button--withChrome.is-active:n
 	background-color: transparent !important;
 }
 
-div.popover,
+div.popover {
+	background: #1D1D1D !important;
+}
+
 .readNextPromo,
 footer .container > div {
 	background: transparent none !important;

--- a/style.css
+++ b/style.css
@@ -154,7 +154,7 @@ body .u-tintSpectrum .u-accentColor--buttonNormal.button--withChrome.is-active:n
 }
 
 div.popover {
-	background: #1D1D1D !important;
+	background: #1d1d1d !important;
 }
 
 .readNextPromo,


### PR DESCRIPTION
I've noticed that the menu that's displayed when you click on the profile icon (when you are login)
appears transparent ([screenshot](https://user-images.githubusercontent.com/723651/33806412-6a9eb054-ddd0-11e7-83b8-8524bf8008ce.jpg)),

Separating the existing rule, seems to fix the issue, alright.
Hope you agree, @Mottie 🙂 


_Using Stylus 1.1.7.8 in Firefox 57.0.2_